### PR TITLE
Avoid overlap on graph

### DIFF
--- a/docs/network.js
+++ b/docs/network.js
@@ -119,6 +119,12 @@ function build(data) {
                 to: true
             }
         },
+        physics: {
+          solver: "forceAtlas2Based",
+          forceAtlas2Based: {
+            avoidOverlap: 1
+          }
+        },
         interaction: {
             hover: true
         }


### PR DESCRIPTION
Untangles the graph a bit.

Before:
<img width="786" alt="before" src="https://user-images.githubusercontent.com/2472141/33266861-1fa7411c-d36f-11e7-9a14-562f33cbffd7.png">

After:
<img width="741" alt="after" src="https://user-images.githubusercontent.com/2472141/33266869-24f04f88-d36f-11e7-82c7-edd21c550b95.png">
