### PR TITLE
HOTFIX: correct swagger document publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ before_install:
   - curl https://raw.githubusercontent.com/hmcts/reform-api-docs/master/bin/publish-swagger-docs.sh > publish-swagger-docs.sh
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" = "false" ]; then ./publish-swagger-docs.sh; fi
+  - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh
 ```
 
 Script assumes you have configured `docker-compose.yml` and `.env` files as per example in [Spring Boot Template](https://github.com/hmcts/spring-boot-template) repository

--- a/bin/publish-swagger-docs.sh
+++ b/bin/publish-swagger-docs.sh
@@ -5,7 +5,7 @@
 set -e
 
 # assign environment variables
-source .env
+. ./.env
 
 ./gradlew clean installDist
 


### PR DESCRIPTION
- Use test function provided with travis integration
- Use `.` since `source` is not supported