### PR TITLE
Added divorce miroservice and its dependencies

### DIFF
--- a/docs/microservices.json
+++ b/docs/microservices.json
@@ -27,6 +27,10 @@
         {
             "name": "CMC",
             "colour": "#f30000"
+        },
+        {
+            "name": "Divorce",
+            "colour": "#c0392b"
         }
     ],
     "apis": [
@@ -496,6 +500,93 @@
                 },
                 {
                     "id": "idam-s2s",
+                    "hard": true,
+                    "apis": []
+                }
+            ],
+            "apis": [],
+            "version": null
+        },
+        {
+            "id": "transformation-api",
+            "name": "Transformation API",
+            "group": "Divorce",
+            "description": null,
+            "repository": null,
+            "spec": null,
+            "dependencies": [
+                {
+                    "id": "ccd-data-store",
+                    "hard": true,
+                    "apis": []
+                },
+                {
+                    "id": "idam-s2s",
+                    "hard": true,
+                    "apis": []
+                }
+            ],
+            "apis": [],
+            "version": null
+        },
+        {
+            "id": "evidence-management-client-api",
+            "name": "Evidence Management Client API",
+            "group": "Divorce",
+            "description": null,
+            "repository": null,
+            "spec": null,
+            "dependencies": [
+                {
+                    "id": "document-management-store-api-gateway-web",
+                    "hard": true,
+                    "apis": []
+                }
+            ],
+            "apis": [],
+            "version": null
+        },
+        {
+            "id": "divorce-pdf-generator",
+            "name": "PDF Generator",
+            "group": "Divorce",
+            "description": null,
+            "repository": null,
+            "spec": null,
+            "dependencies": [],
+            "apis": [],
+            "version": null
+        },
+        {
+            "id": "divorce-frontend",
+            "name": "Frontend",
+            "group": "Divorce",
+            "description": null,
+            "repository": null,
+            "spec": null,
+            "dependencies": [
+                {
+                    "id": "idam-web",
+                    "hard": true,
+                    "apis": []
+                },
+                {
+                    "id": "payments",
+                    "hard": true,
+                    "apis": []
+                },
+                {
+                    "id": "transformation-api",
+                    "hard": true,
+                    "apis": []
+                },
+                {
+                    "id": "evidence-management-client-api",
+                    "hard": true,
+                    "apis": []
+                },
+                {
+                    "id": "divorce-pdf-generator",
                     "hard": true,
                     "apis": []
                 }


### PR DESCRIPTION
<img width="1445" alt="screen shot 2018-01-10 at 11 58 38" src="https://user-images.githubusercontent.com/13840402/34771833-da4e9424-f5fd-11e7-9aab-ad69de9695da.png">
- Included Divorce Micro service and it's dependencies as below

- Divorce Front End
  - Transformation API
  - Evidence Management Client API
  - PDF Generator
  - Payments
  - Case data store

## Pending

- Currently Divorce repository is not open sourced and since I don't have the access to HMCTS Git repository I have not updated repository URL section in microservices.json file.Will update once I get access.