### PR TITLE
Fix vulnerability reported in github

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -219,9 +219,9 @@
       }
     },
     "moment": {
-      "version": "2.19.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
-      "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc="
+      "version": "2.19.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
+      "integrity": "sha512-1xFTAknSLfc47DIxHDUbnJWC+UwgWxATmymaxIPQpmMh7LBm7ZbwVEsuushqwL2GYZU0jie4xO+TK44hJPjNSQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -325,7 +325,7 @@
         "emitter-component": "1.1.1",
         "hammerjs": "2.0.8",
         "keycharm": "0.2.0",
-        "moment": "2.19.1",
+        "moment": "2.19.4",
         "propagating-hammerjs": "1.4.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "djv": "^2.0.0",
     "jasmine": "^2.8.0",
     "swagger-ui-dist": "^3.4.3",
-    "vis": "^4.21.0"
+    "vis": "^4.21.0",
+    "moment": "~2.19.3"
   },
   "devDependencies": {
     "http-server": "^0.10.0"


### PR DESCRIPTION
[Report](https://nvd.nist.gov/vuln/detail/CVE-2017-18214)

`vis` dependency drags in `moment ~> 2.19.1` which just got reported as vulnerable package.