### PR TITLE
Fix commit message

### DIFF
--- a/bin/publish-swagger-docs.sh
+++ b/bin/publish-swagger-docs.sh
@@ -36,7 +36,7 @@ elif [ "$CURRENT_DOCS" != "$NEW_DOCS" ]; then
     echo "$NEW_DOCS" > "$TARGET_SPEC"
 
     git add "$TARGET_SPEC"
-    git commit -m "Updating spec for $REPO_NAME from $TRAVIS_PULL_REQUEST_SLUG"
+    git commit -m "Update spec from $TRAVIS_REPO_SLUG build $TRAVIS_BUILD_NUMBER"
     git push --set-upstream upstream master
 else
     echo "API Documentation is up to date."


### PR DESCRIPTION
Script is using pull request slug but is executed against master. Hence causing this:

| spec | commit message | when |
| ----- | ---------------- | ------ |
| cmc-pdf-service.json | Updating spec for cmc-pdf-service from | 4 months ago |
| document-management-store-app.json | update | 2 months ago |
| draft-store.json | Updating spec for draft-store from hmcts/draft-store | 5 months ago |
| em-annotation-app.json | em app | 2 months ago |
| em-redaction-app.json | em app | 2 months ago |
| job-scheduler.json | Updating spec for job-scheduler from | 2 months ago |
| send-letter-producer-service.json | Updating spec for send-letter-producer-service from | a month ago |