### PR TITLE
Build both versions of gradle application

### DIFF
--- a/bin/publish-swagger-docs.sh
+++ b/bin/publish-swagger-docs.sh
@@ -6,7 +6,7 @@
 # shellcheck disable=SC1091
 . ./.env
 
-./gradlew clean installDist
+./gradlew clean assemble installDist
 
 docker-compose up -d
 


### PR DESCRIPTION
Since Spring Boot 2, the changes in application boot run makes `installDist` not recommended to use. With complete and correct docker set up and build.gradle file (check spring boot template) `assemble` now is the required step.
Making both version work with single word append