### PR TITLE
Fix older version of spring boot

### DIFF
--- a/bin/publish-swagger-docs.sh
+++ b/bin/publish-swagger-docs.sh
@@ -6,7 +6,9 @@
 # shellcheck disable=SC1091
 . ./.env
 
-./gradlew clean assemble installDist
+./gradlew clean
+./gradlew assemble
+./gradlew installDist
 
 docker-compose up -d
 


### PR DESCRIPTION
Individual calls to gradle tasks don't break the scripts for spring boot applications causing failure to load app with `could not find or load main class uk.gov.hmcts.reform.demo.Application`