### PR TITLE
Simplify swagger specs publisher script

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,5 +89,3 @@ before_install:
 after_success:
   - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh
 ```
-
-Script assumes you have configured `docker-compose.yml` and `.env` files as per example in [Spring Boot Template](https://github.com/hmcts/spring-boot-template) repository

--- a/bin/publish-swagger-docs.sh
+++ b/bin/publish-swagger-docs.sh
@@ -1,31 +1,10 @@
-#!/usr/bin/env bash
-# Runs the api and backend db, grabs the generated swagger json spec and compares to what is in the
-# central reform-api-docs repo. Updates reform-api-docs spec if needed
-
-# assign environment variables
-# shellcheck disable=SC1091
-. ./.env
-
-./gradlew clean
-./gradlew assemble
-./gradlew installDist
-
-docker-compose up -d
-
-sleep 15
-wget --retry-connrefused --tries=120 --waitretry=1 -O /dev/null http://localhost:$SERVER_PORT/health
-#curl --retry-connrefused --retry 120 --retry-delay 1 http://localhost:{$SERVER_PORT}/health
+#!/usr/bin/env sh
 
 REPO_NAME=$(echo "$TRAVIS_REPO_SLUG" | cut -f2- -d/)
 CURRENT_DOCS=$(curl https://hmcts.github.io/reform-api-docs/specs/"$REPO_NAME".json)
-NEW_DOCS=$(curl http://localhost:"$SERVER_PORT"/v2/api-docs)
+NEW_DOCS=$(cat /tmp/swagger-specs.json)
 
-docker-compose stop
-
-if [ "$NEW_DOCS" = "" ]; then
-    echo "Could not retrieve new docs, aborting."
-    docker-compose logs
-elif [ "$CURRENT_DOCS" != "$NEW_DOCS" ]; then
+if [ "$CURRENT_DOCS" != "$NEW_DOCS" ]; then
     echo "Update reform-api-docs"
     mkdir swagger-staging
     cd swagger-staging


### PR DESCRIPTION
Simplify documentation publishing by getting rid of docker dependency. The exact implementation is in [spring boot template](https://github.com/hmcts/spring-boot-template)