### PR TITLE
Correct SSCS dependency on docmosis (not assembly)

### DIFF
--- a/docs/microservices.json
+++ b/docs/microservices.json
@@ -1741,7 +1741,7 @@
                     "apis": []
                 },
                 {
-                    "id": "rpa-dg-docassembly-api",
+                    "id": "docmosis-tornado-api",
                     "hard": true,
                     "apis": []
                 }
@@ -1792,7 +1792,7 @@
                     "apis": []
                 },
                 {
-                    "id": "rpa-dg-docassembly-api",
+                    "id": "docmosis-tornado-api",
                     "hard": true,
                     "apis": []
                 },


### PR DESCRIPTION
### Change description ###

Minor dependency correction - docmosis not doc assembly.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
