### PR TITLE
Updated link to the ccpay API

### DIFF
--- a/docs/microservices.json
+++ b/docs/microservices.json
@@ -227,7 +227,7 @@
             "type": "api",
             "description": "",
             "repository": "https://github.com/hmcts/ccpay-payment-app",
-            "spec": "https://hmcts.github.io/reform-api-docs/specs/ccpay-payment-app.json",
+            "spec": "https://hmcts.github.io/reform-api-docs/specs/ccpay-payment-app.payment2.json",
             "dependencies": [
                 {
                     "id": "rpe-service-auth-provider",


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/PAY-1621

### Change description ###

Due to ccpay having API in groups, an updated link to the spec has been done inside microservices.json to correctly point to the spec in the graph.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
