### PR TITLE
Deploy the site from Actions, and smoke-test the deployment

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -1,7 +1,8 @@
 name: Build site
 
-# Does not deploy: the Pages source is still master:/docs. Switching Pages to
-# "GitHub Actions" is a separate, manual step.
+# Pull requests build and verify only. Pushes to master also deploy, which takes
+# effect once the Pages source is set to "GitHub Actions" — until then the deploy
+# step is a no-op against the legacy branch source.
 
 on:
   push:
@@ -85,10 +86,53 @@ jobs:
             echo "- pages: $(find build/dist -name '*.html' | wc -l)"
             echo "- specs served verbatim: $(find build/dist/specs -maxdepth 1 -name '*.json' ! -name '.json' | wc -l)"
             echo "- normalised for rendering: $(find build/dist/specs/_normalised -name '*.json' | wc -l)"
-            echo
-            echo "Not deployed: the Pages source is still \`master:/docs\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-pages-artifact@v3
         with:
           path: build/dist
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - id: deploy
+        uses: actions/deploy-pages@v4
+
+      # These URLs are fetched at runtime by rpx-xui-webapp, asserted on by the
+      # CCD and HMC F-125 tests, and read by terraform at apply time. Checked
+      # against the live site after deploying, not just in the artifact.
+      - name: Smoke-test the deployed site
+        run: |
+          base='${{ steps.deploy.outputs.page_url }}'
+          base="${base%/}"
+          fail=0
+
+          check() {
+            code=$(curl -fsS -o /dev/null -w '%{http_code}' --retry 5 --retry-delay 4 --retry-all-errors "$1" || echo 000)
+            [ "$code" = "200" ] || { echo "::error::$code $1"; fail=1; }
+          }
+
+          for name in \
+            am-role-assignment-service am-judicial-booking-service future-hearings-hmi-api \
+            rd-location-ref-api rd-judicial-api rd-caseworker-ref-api \
+            ccd-data-store-api.v1_internal ccd-data-store-api.v1_external \
+            ccd-data-store-api.v2_internal ccd-data-store-api.v2_external \
+            ccd-user-profile-api hmc-hmi-inbound-adapter \
+            ccpay-payment-app.recon-payments-v0.3 ccpay-payment-app.refunds-status-v1 \
+            et-acas-api et-acas-api-nonprod
+          do
+            check "$base/specs/$name.json"
+          done
+
+          # The legacy entry points other repos and Confluence link to.
+          check "$base/swagger.html"
+          check "$base/lld/ccd.html"
+          check "$base/"
+          check "$base/products/ccd/"
+
+          exit $fail


### PR DESCRIPTION
## Summary

Prerequisite for the Pages cutover. `build-site` uploaded a Pages artifact but had **no `deploy-pages` step**, so flipping the Pages source to "GitHub Actions" would have taken the site **down** rather than switching it over — there would never have been a published deployment to serve.

- Adds a `deploy` job, `needs: build`, skipped on pull requests.
- Adds a smoke test that runs against the **deployed URL**, not the local artifact: the 16 spec URLs other services depend on, plus `swagger.html`, `lld/ccd.html`, `/` and a product page. Retries, because Pages propagation isn't instant.

**Inert until the Pages source is changed.** With the legacy `master:/docs` source, `deploy-pages` publishes nothing, so merging this on its own changes nothing that users see.

## Test plan

- [x] Workflow parses; `deploy` correctly gated to non-PR events
- [x] `build` job unchanged and still passing
- [ ] After merge: confirm the deploy job runs green on master while Pages is still legacy
- [ ] Then flip the Pages source, and confirm the smoke test passes against the live URL