### PR TITLE
FPVTL-3528: Add CourtNav document upload documentation

### DIFF
--- a/docs/specs/court_nav.json
+++ b/docs/specs/court_nav.json
@@ -71,6 +71,69 @@
           }
         }
       }
+    },
+    "/{caseId}/document": {
+      "post": {
+        "description": "Upload a document to a case in CCD",
+        "operationId": "uploadDocument",
+        "summary": "Upload a document to a case in CCD",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "caseId",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "ID of the case"
+          },
+          {
+            "name": "file",
+            "in": "formData",
+            "required": true,
+            "type": "file",
+            "description": "Document file to upload"
+          },
+          {
+            "name": "typeOfDocument",
+            "in": "formData",
+            "required": true,
+            "type": "string",
+            "description": "Type of document being uploaded"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Document uploaded successfully",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            },
+            "examples": {
+              "application/json": {
+                "message": "Document has been uploaded successfully: sample.pdf"
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
     }
   }
 }

--- a/docs/specs/court_nav.json
+++ b/docs/specs/court_nav.json
@@ -74,9 +74,9 @@
     },
     "/{caseId}/document": {
       "post": {
-        "description": "Upload a document to a case in CCD",
+        "description": "Upload a document to a CourtNav created case in CCD",
         "operationId": "uploadDocument",
-        "summary": "Upload a document to a case in CCD",
+        "summary": "Upload a document to a CourtNav created case in CCD",
         "consumes": [
           "multipart/form-data"
         ],
@@ -93,14 +93,23 @@
             "in": "formData",
             "required": true,
             "type": "file",
-            "description": "Document file to upload"
+            "description": "Document file to upload, must be of type pdf/jpeg/jpg/doc/docx/bpm/png/tiff/txt/tif"
           },
           {
             "name": "typeOfDocument",
             "in": "formData",
             "required": true,
             "type": "string",
+            "enum": ["WITNESS_STATEMENT", "EXHIBITS_EVIDENCE", "EXHIBITS_COVERSHEET", "C8_DOCUMENT"],
             "description": "Type of document being uploaded"
+          },
+          {
+            "name": "documentId",
+            "in": "formData",
+            "required": false,
+            "type": "string",
+            "format": "uuid",
+            "description": "Optional UUID parameter to ensure document uniqueness. If not provided, the document will be processed as a unique copy."
           }
         ],
         "produces": [


### PR DESCRIPTION
### Jira link
[FPVTL-3528](https://tools.hmcts.net/jira/browse/FPVTL-3528)
### Change description
 - Add documentation of existing document upload endpoint
 - Add addition of **OPTIONAL** document Id parameter, will be developed in future work.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [X] README and other documentation has been updated / added (if needed)
- [X] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
